### PR TITLE
chore: Remove scheduled trigger from nightly performance workflow

### DIFF
--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -1,10 +1,6 @@
 name: Nightly Performance Benchmarks
 
 on:
-  schedule:
-    # Run nightly at 2:00 AM UTC
-    - cron: "0 2 * * *"
-
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Disabled automatic nightly performance workflow runs. Manual dispatch is now the only way to trigger performance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->