### PR TITLE
fix: perf workflow - push only if changes exist

### DIFF
--- a/.github/workflows/nightly-performance.yml
+++ b/.github/workflows/nightly-performance.yml
@@ -111,9 +111,8 @@ jobs:
           # Pull latest changes with rebase
           git pull --rebase origin main
 
-          # Commit and push
-          git commit -m "chore: update performance baseline - $(date +%Y-%m-%d)"
-          git push
+          # Push only if we’re ahead
+          git rev-list --count origin/main..HEAD | grep -q '^[1-9][0-9]*$' && git push || echo "Nothing to push."
       - name: Create issue for regressions
         if: steps.regression-check.outputs.has_regression == 'true'
         uses: actions/github-script@v7


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized nightly performance workflow to reduce unnecessary pushes, pushing baseline updates only when there are new commits to synchronize.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->