### PR TITLE
fix: Remove unused 'gen2' field from baseline loading

### DIFF
--- a/.github/scripts/compare-benchmarks.py
+++ b/.github/scripts/compare-benchmarks.py
@@ -215,7 +215,6 @@ def load_baseline(path: str) -> tuple[dict[str, BenchmarkResult], str]:
             allocated_bytes=bench.get("allocated_bytes", 0),
             gen0=bench.get("gen0", 0),
             gen1=bench.get("gen1", 0),
-            gen2=bench.get("gen2", 0),
         )
 
     baseline_date = data.get("date", "unknown")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected memory benchmark reporting to use only gen0 and gen1 metrics, removing the previously included gen2 field for more accurate performance measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->